### PR TITLE
port to logstash 2.x and add ldap ssl connection

### DIFF
--- a/logstash-input-LDAPSearch.gemspec
+++ b/logstash-input-LDAPSearch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-LDAPSearch'
-  s.version         = '0.1.0'
+  s.version         = '0.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "logstash input plugin to perform search into ldap."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = `git ls-files`.split($\)+::Dir.glob('vendor/*')
+  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
+  s.add_runtime_dependency "logstash-core", '> 1.5.0', '< 3.0.0'
 
   s.add_runtime_dependency 'jruby-ldap'
   #s.add_runtime_dependency 'ruby_base64'


### PR DESCRIPTION
je commence avec Agimus-ng et je suis parti sur du elk 2+. 
J'ai donc du rendre fonctionnel votre pluging pour logstash 2+ et j'en ai profité pour rajouter le support de connexion ldap ssl (note, les certificats doivent être dans le keystore jvm).
